### PR TITLE
[Indentation] Excludes a buffer type.

### DIFF
--- a/lua/diegognt/indentation.lua
+++ b/lua/diegognt/indentation.lua
@@ -8,5 +8,5 @@ end
 indent_blankline.setup {
   show_end_of_line = true,
   space_char_blankline = " ",
-  filetype_exclude = { 'alpha' }
+  filetype_exclude = { 'alpha', 'toggleterm' }
 }


### PR DESCRIPTION
This PR includes:
  - Excluding `toggleterm` buffer for be indented.