### PR TITLE
[General] Plugin updates.

### DIFF
--- a/lua/diegognt/completion.lua
+++ b/lua/diegognt/completion.lua
@@ -121,8 +121,11 @@ cmp.setup {
     behavior = cmp.ConfirmBehavior.Replace,
     select = false,
   },
-  documentation = {
-    border = { '╭', '─', '╮', '│', '╯', '─', '╰', '│' },
+  window = {
+    completion = cmp.config.window.bordered()
+    -- documentation = {
+    --   border = { '╭', '─', '╮', '│', '╯', '─', '╰', '│' },
+    -- },
   },
   experimental = {
     ghost_text = true,

--- a/lua/diegognt/lsp/null-ls.lua
+++ b/lua/diegognt/lsp/null-ls.lua
@@ -13,8 +13,15 @@ local diagnostics = null_ls.builtins.diagnostics
 null_ls.setup({
 	debug = false,
 	sources = {
-		diagnostics.eslint,
-		formatting.prettier,
+		diagnostics.eslint.with({
+			dynamic_command = require('null-ls.helpers.command_resolver').from_node_modules,
+		}),
+		formatting.prettier.with({
+			dynamic_command = require('null-ls.helpers.command_resolver').from_node_modules,
+		}),
+		formatting.stylelint.with({
+			command = 'npx stylelint',
+		}),
 		formatting.stylua,
 		diagnostics.flake8,
 	},

--- a/lua/diegognt/plugins.lua
+++ b/lua/diegognt/plugins.lua
@@ -96,6 +96,7 @@ return packer.startup(function(use)
   }
   use 'p00f/nvim-ts-rainbow' -- Better parentheses rainbow using treesitter
   use 'JoosepAlviste/nvim-ts-context-commentstring'
+  use 'nvim-treesitter/nvim-tree-docs'
 
   -- Git stuff
   use 'lewis6991/gitsigns.nvim'

--- a/lua/diegognt/treesitter.lua
+++ b/lua/diegognt/treesitter.lua
@@ -5,7 +5,7 @@ if not status_ok then
 end
 
 configs.setup {
-  ensure_installed = 'maintained', -- one of 'all', 'maintained' (parsers with maintainers), or a list of languages
+  ensure_installed = 'all', -- one of 'all', 'maintained' (parsers with maintainers), or a list of languages
   sync_install = false, -- install languages synchronously (only applied to `ensure_installed`)
   ignore_install = { '' }, -- List of parsers to ignore installing
   autopairs = {
@@ -28,5 +28,15 @@ configs.setup {
   context_commentstring = {
     enable = true,
     enable_autocmd = false
+  },
+  tree_docs = {
+    enable = true,
+    spec_config = {
+      jsdoc = {
+        slots = {
+          class = {author = true}
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR includes:
 - `hrsh7th/nvim-cmp` updadates for pop-up border API.
 - Treesitter plugin for JSDoc.
 - Using `all` for `ensure_installed` config property.
 - Null-ls now request `prettier` and `eslint` from node_modules