### PR TITLE
[Treesitter] Autoclose and autorename HTML tags.

### DIFF
--- a/lua/diegognt/plugins.lua
+++ b/lua/diegognt/plugins.lua
@@ -97,6 +97,7 @@ return packer.startup(function(use)
   use 'p00f/nvim-ts-rainbow' -- Better parentheses rainbow using treesitter
   use 'JoosepAlviste/nvim-ts-context-commentstring'
   use 'nvim-treesitter/nvim-tree-docs'
+  use 'windwp/nvim-ts-autotag'
 
   -- Git stuff
   use 'lewis6991/gitsigns.nvim'

--- a/lua/diegognt/treesitter.lua
+++ b/lua/diegognt/treesitter.lua
@@ -16,7 +16,10 @@ configs.setup {
     disable = { '' }, -- list of language that will be disabled
     additional_vim_regex_highlighting = true,
   },
-  indent = { enable = true, disable = { 'yaml' } },
+  indent = {
+    enable = true,
+    disable = { 'yaml' }
+   },
   rainbow = {
     enable = true,
     -- disable = { "jsx", "cpp" }, list of languages you want to disable the plugin for
@@ -29,14 +32,7 @@ configs.setup {
     enable = true,
     enable_autocmd = false
   },
-  tree_docs = {
-    enable = true,
-    spec_config = {
-      jsdoc = {
-        slots = {
-          class = {author = true}
-        }
-      }
-    }
-  }
+  autotag = { -- `Uses windwp/nvim-ts-autotag` to autoclose or autoremane HTML tags.
+    enable = true
+  },
 }


### PR DESCRIPTION
This PR includes:
  - Used the `windwp/nvim-ts-autotag`.
  - Removed some unused code for the treesitter configuration.