### PR TITLE
Updates for v0.8.0 of Neovim.

### DIFF
--- a/lua/diegognt/lsp/handlers.lua
+++ b/lua/diegognt/lsp/handlers.lua
@@ -8,7 +8,7 @@ end
 
 M.capabilities = vim.lsp.protocol.make_client_capabilities()
 M.capabilities.textDocument.completion.completionItem.snippetSupport = true
-M.capabilities = cmp_nvim_lsp.update_capabilities(M.capabilities)
+M.capabilities = cmp_nvim_lsp.default_capabilities(M.capabilities)
 
 M.setup = function()
   local signs = {
@@ -55,27 +55,27 @@ end
 
 M.on_attach = function(client)
   if client.name == 'tsserver' then
-    client.resolved_capabilities.document_formatting = false
+    client.server_capabilities.document_formatting = false
   end
 
   if client.name == 'sumneko_lua' then
-    client.resolved_capabilities.document_formatting = false
+    client.server_capabilities.document_formatting = false
   end
 
   if client.name == 'pyright' then
-    client.resolved_capabilities.document_formatting = false
+    client.server_capabilities.document_formatting = false
   end
 
   if client.name == 'cssls' then
-    client.resolved_capabilities.document_formatting = false
+    client.server_capabilities.document_formatting = false
   end
 
   if client.name == 'jsonls' then
-    client.resolved_capabilities.document_formatting = true
+    client.server_capabilities.document_formatting = true
   end
 
   if client.name == 'astro' then
-    client.resolved_capabilities.document_formatting = false
+    client.server_capabilities.document_formatting = false
   end
 end
 

--- a/lua/diegognt/nvim-tree.lua
+++ b/lua/diegognt/nvim-tree.lua
@@ -80,12 +80,8 @@ nvim_tree.setup({
     timeout = 500,
   },
   view = {
-    width = 30,
-    height = 30,
     hide_root_folder = false,
-    side = 'left',
     mappings = {
-      custom_only = false,
       list = {
         { key = { 'l', '<CR>', 'o' }, cb = tree_cb('edit') },
         { key = 'h', cb = tree_cb('close_node') },


### PR DESCRIPTION
This PR includes:
  - Replace old LSP API methods for new ones
  - Updates the set up properties for nvim-tree