### PR TITLE
LSP, adding `clangd` for C++ development.

### DIFF
--- a/lua/diegognt/lsp/README.md
+++ b/lua/diegognt/lsp/README.md
@@ -1,0 +1,12 @@
+# Language Server Protocol
+
+Follow the instructions bellow to use some of the LSP available.
+
+## C, C++
+Please install the [clangd](https://clangd.llvm.org/installation.html) LSP for C and C++ development.
+
+### On Arch Linux
+Make sure you install the following packages:
+~~~sh
+sudo pacman -S curl file git cmake clang
+~~~

--- a/lua/diegognt/lsp/lsp-installer.lua
+++ b/lua/diegognt/lsp/lsp-installer.lua
@@ -9,6 +9,7 @@ local servers = {
   'bashls',
   'cmake',
   'cssls',
+  'clangd',
   'dockerls',
   'gopls',
   'html',


### PR DESCRIPTION
This PR includes:
  - Adding `clangd` to the LSP installer config table
  - Adding the instruction to make `clangd` works on Arch linux