### PR TITLE
Added neotest plugin and its key mappings.

### DIFF
--- a/lua/diegognt/autocommands.lua
+++ b/lua/diegognt/autocommands.lua
@@ -45,6 +45,8 @@ vim.api.nvim_create_autocmd('FileType', {
     'startuptime',
     'tsplayground',
     'PlenaryTestPopup',
+    'neotest-summary',
+    'neotest-output-panel',
   },
   callback = function(event)
     vim.bo[event.buf].buflisted = false

--- a/lua/diegognt/plugins.lua
+++ b/lua/diegognt/plugins.lua
@@ -144,26 +144,26 @@ return lazy.setup({
 
   --Completion plugins
   {
-    'hrsh7th/nvim-cmp',           -- The completion plugin
+    'hrsh7th/nvim-cmp', -- The completion plugin
     dependencies = {
-      'hrsh7th/cmp-buffer',       -- The buffer completions plugin extension
-      'hrsh7th/cmp-path',         -- The path completions plugin extension
-      'hrsh7th/cmp-cmdline',      -- The cmdline completions plugin extension
+      'hrsh7th/cmp-buffer', -- The buffer completions plugin extension
+      'hrsh7th/cmp-path', -- The path completions plugin extension
+      'hrsh7th/cmp-cmdline', -- The cmdline completions plugin extension
       'saadparwaiz1/cmp_luasnip', -- The LuaSnip completions plugin extension
-      'hrsh7th/cmp-nvim-lsp',     -- The LSP completion plugin extension
-      'hrsh7th/cmp-nvim-lua',     -- The Lua language completion plugin extension
+      'hrsh7th/cmp-nvim-lsp', -- The LSP completion plugin extension
+      'hrsh7th/cmp-nvim-lua', -- The Lua language completion plugin extension
     },
     event = 'InsertEnter',
   },
   -- Snippets
-  'L3MON4D3/LuaSnip',             -- A snippet engine
+  'L3MON4D3/LuaSnip', -- A snippet engine
   'rafamadriz/friendly-snippets', -- A bunch of snippets to use
 
   -- Language Server Protocol - LSP
   {
-    'neovim/nvim-lspconfig',               -- Enables LSP
+    'neovim/nvim-lspconfig', -- Enables LSP
     dependencies = {
-      'williamboman/mason.nvim',           -- Manager
+      'williamboman/mason.nvim', -- Manager
       'williamboman/mason-lspconfig.nvim', -- LSP adapter for Mason
       -- Highlighting words occurance
       {
@@ -175,7 +175,7 @@ return lazy.setup({
   -- Null-ls
   {
     'jose-elias-alvarez/null-ls.nvim',
-    opts = function ()
+    opts = function()
       local builtins = require('null-ls.builtins')
       local opts = require('diegognt.null-ls')
       return opts.opts(builtins.formatting, builtins.diagnostics)
@@ -347,5 +347,24 @@ return lazy.setup({
       },
     },
     event = 'VeryLazy',
+  },
+
+  -- Testing
+  {
+    'nvim-neotest/neotest',
+    dependencies = {
+      'nvim-lua/plenary.nvim',
+      'nvim-treesitter/nvim-treesitter',
+      'antoinemadec/FixCursorHold.nvim',
+      'marilari88/neotest-vitest',
+    },
+    version = 'v3.x',
+    config = function()
+      require('neotest').setup({
+        adapters = {
+          require('neotest-vitest'),
+        },
+      })
+    end,
   },
 })

--- a/lua/diegognt/whichkey.lua
+++ b/lua/diegognt/whichkey.lua
@@ -179,6 +179,13 @@ M.mappings = {
     h = { '<cmd>ToggleTerm size=10 direction=horizontal<CR>', 'Horizontal' },
     v = { '<cmd>ToggleTerm size=80 direction=vertical<CR>', 'Vertical' },
   },
+  T = {
+    name = 'Test',
+    r = { '<cmd>lua require("neotest").run.run()<CR>', 'Run nearest' },
+    f = { '<cmd>lua require("neotest").run.run(vim.fn.expand("%"))<CR>', 'Run File' },
+    p = { '<cmd>lua require("neotest").output_panel.open()<CR>', 'Panel' },
+    s = { '<cmd>lua require("neotest").summary.open()<CR>', 'Tests Summary' },
+  },
   x = {
     name = 'Diagnostic',
     d = { '<cmd>Trouble document_diagnostics<CR>', 'Document' },


### PR DESCRIPTION
This commit adds:
  - The neotest plugin
  - Several neotest commands to the key mapping table, including:
    - running the nearest test
    - running tests in a file
    - opening the output panel
    - opening the tests summary.