### PR TITLE
Adding color highlighting.

### DIFF
--- a/lua/diegognt/plugins.lua
+++ b/lua/diegognt/plugins.lua
@@ -367,4 +367,18 @@ return lazy.setup({
       })
     end,
   },
+
+  -- Color Highlighting
+  {
+    'uga-rosa/ccc.nvim',
+    event = 'BufRead',
+    config = function()
+      require('ccc').setup({
+        highlighter = {
+          auto_enable = true,
+          lsp = true,
+        },
+      })
+    end,
+  },
 })


### PR DESCRIPTION
This commit adds:
  - Added color highlighting feature using uga-rosa/ccc.nvim plugin.
  - Enable automatic LSP-based highlighting.